### PR TITLE
Fix replacement of people in worklog entry

### DIFF
--- a/test/log_entry_test.rb
+++ b/test/log_entry_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require_relative 'test_helper'
 require_relative '../worklog/log_entry'
+require_relative '../worklog/person'
 
 class LogEntryTest < Minitest::Test
   def setup
@@ -55,6 +56,17 @@ class LogEntryTest < Minitest::Test
     @log_entry.epic = false
     msg_string = @log_entry.message_string
     assert_includes msg_string, 'This is a message'
+  end
+
+  def test_message_string_replace_people
+    known_people = {
+      'person1' => Person.new('person1', 'Person One', '', 'Team A'),
+      'person2' => Person.new('person2', 'Person Two', '', 'Team A')
+    }
+    msg_string = LogEntry.new(message: 'This is a message with a mention of ~person1 and ~person2').message_string(known_people)
+    refute_nil msg_string
+    assert_includes msg_string, 'Person One'
+    assert_includes msg_string, 'Person Two'
   end
 
   def test_people?

--- a/worklog/log_entry.rb
+++ b/worklog/log_entry.rb
@@ -38,7 +38,7 @@ class LogEntry
     people.each do |person|
       next unless known_people && known_people[person]
 
-      msg.gsub!(PERSON_REGEX) do |match|
+      msg.gsub!(/[~@]#{person}/) do |match|
         s = ''
         s += ' ' if match[0] == ' '
         s += "#{Rainbow(known_people[person].name).underline} (~#{person})" if known_people && known_people[person]


### PR DESCRIPTION
This PR fixes the LogEntry#message_string by replacing the correct person