### PR TITLE
Detect people at beginning of message

### DIFF
--- a/lib/log_entry.rb
+++ b/lib/log_entry.rb
@@ -7,7 +7,7 @@ require 'hash'
 
 # A single log entry.
 class LogEntry
-  PERSON_REGEX = /\s[~@](\w+)/
+  PERSON_REGEX = /(?:\s|^)[~@](\w+)/
 
   include Hashify
 

--- a/test/log_entry_test.rb
+++ b/test/log_entry_test.rb
@@ -111,6 +111,10 @@ class LogEntryTest < Minitest::Test
     # Test @ sign
     @log_entry.message = 'This is a message with a mention of @person1 and @person2'
     assert_equal %w[person1 person2], @log_entry.people
+
+    # Test person in the beginning
+    @log_entry.message = '~person1 This is a message with a mention of ~person2'
+    assert_equal %w[person1 person2], @log_entry.people
   end
 
   def test_to_yaml


### PR DESCRIPTION
This change fixes an issue that prevented people from being detected when they were at the beginning of the message.