### PR TITLE
Rephrase "Created" to "Opened" in Github PR

### DIFF
--- a/lib/github/pull_request_event.rb
+++ b/lib/github/pull_request_event.rb
@@ -56,7 +56,7 @@ module Worklog
                   elsif closed?
                     'Closed PR '
                   else
-                    'Created PR '
+                    'Opened PR '
                   end
         message += title
 


### PR DESCRIPTION
This changes the wording from "Created PR" to "Opened PR" which is more clear.