### PR TITLE
Add emojis for different sources

### DIFF
--- a/lib/log_entry_formatters.rb
+++ b/lib/log_entry_formatters.rb
@@ -32,6 +32,9 @@ module Worklog
 
       protected
 
+      # Prefix emoji for the log entry based on its source.
+      # @param log_entry [LogEntry] The log entry to get the source prefix for.
+      # @return [String] The emoji prefix for the source (🐙 for github, ✍️ for manual, empty string otherwise).
       def source_prefix(log_entry)
         case log_entry.source
         when 'github'

--- a/lib/log_entry_formatters.rb
+++ b/lib/log_entry_formatters.rb
@@ -21,6 +21,7 @@ module Worklog
         # replace all mentions of people with their names.
         msg = log_entry.message.dup
         s = String.new
+        s << source_prefix(log_entry)
         s << epic_prefix if log_entry.epic
         s << replace_people_handles(log_entry, msg)
         # Add a space between the message and the metadata if there is any metadata to add.
@@ -30,6 +31,17 @@ module Worklog
       end
 
       protected
+
+      def source_prefix(log_entry)
+        case log_entry.source
+        when 'github'
+          '🐙 '
+        when 'manual'
+          '✍️ '
+        else
+          ''
+        end
+      end
 
       # Prefix for epic entries.
       # @return [String]

--- a/test/log_entry_formatters_test.rb
+++ b/test/log_entry_formatters_test.rb
@@ -21,6 +21,14 @@ class LogEntryFormattersTest < Minitest::Test
     )
   end
 
+  def test_source_prefix
+    formatter = LogEntryFormatters::BaseFormatter.new(@known_people)
+
+    assert_equal '🐙 ', formatter.send(:source_prefix, LogEntry.new(source: 'github'))
+    assert_equal '✍️ ', formatter.send(:source_prefix, LogEntry.new(source: 'manual'))
+    assert_equal '', formatter.send(:source_prefix, LogEntry.new(source: 'other'))
+  end
+
   def test_console_formatter
     formatter = LogEntryFormatters::ConsoleFormatter.new(@known_people)
     formatted_message = formatter.format(@log_entry)


### PR DESCRIPTION
This change adds the octopus emoji for Github entries and the handwritten pencil emoji for manual entries to be able to distinguish the entries more easily visually.